### PR TITLE
Do not release on every push to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release
 
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 
 jobs:
   release:


### PR DESCRIPTION
It doesn't make sense to do a release to PyPI for every commit pushed to the master. We should instead do the releases when we are sure that the code in the master branch is OK to release.

Hence, this PR makes the release workflow run on the `workflow_dispatch` event, which is a manual trigger.