### PR TITLE
Do not expose the fields of the clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The SDK is currently compatible with python 3.8 and above.
 pip install upstash-redis
 ```
 
-
 ## Usage
 To be able to use upstash-redis, you need to create a database on [Upstash](https://console.upstash.com/)
 and grab `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` from the console.
@@ -67,7 +66,6 @@ redis = Redis.from_env()
 from upstash_redis.asyncio import Redis
 redis = Redis.from_env()
 ```
-
 
 If you are in a serverless environment that allows it, it's recommended to initialise the client outside the request handler
 to be reused while your function is still hot.
@@ -110,7 +108,6 @@ the `BITFIELD` and, respectively, `BITFIELD_RO` classes. Use the `execute` funct
     .execute()
 ```
 
-
 ### Custom commands
 If you want to run a command that hasn't been implemented, you can use the `run` function of your client instance
 and pass the command as `list`
@@ -119,40 +116,22 @@ and pass the command as `list`
 redis.run(command=["XLEN", "test_stream"])
 ```
 
-If you want to have more control over your session management or need to use multiple custom values, use
-the [sync_execute](./upstash_redis/http/execute.py) function directly.
-
-
-
 # Encoding
 Although Redis can store invalid JSON data, there might be problems with the deserialization.
 To avoid this, the Upstash REST proxy is capable of encoding the data as base64 on the server and then sending it to the client to be
 decoded. 
 
 For very large data, this can add a few milliseconds in latency. So, if you're sure that your data is valid JSON, you can set
-`rest_encoding` to `False`.
-
+`rest_encoding` to `None`.
 
 # Retry mechanism
 upstash-redis has a fallback mechanism in case of network or API issues. By default, if a request fails it'll retry once, 3 seconds 
 after the error. If you want to customize that, set `rest_retries` and `rest_retry_interval` (in seconds).
 
-
 # Formatting returns
 The SDK relies on the Upstash REST proxy, which returns the `RESP2` responses of the given commands.
 By default, we apply formatting to some of them to provide a better developer experience.
 If you want the commands to output the raw return, set `format_return` to `False`.
-
-You can also opt out of individual commands:
-
-```python
-redis.format_return = False
-
-print(redis.copy(source="source_string", destination="destination_string"))
-
-redis.format_return = True
-```
-
 
 # Contributing
 

--- a/tests/commands/asyncio/bitmap/test_bitop.py
+++ b/tests/commands/asyncio/bitmap/test_bitop.py
@@ -58,8 +58,8 @@ async def test_not() -> None:
         # Manually execute over the REST API because the response is not valid JSON.
         async with ClientSession() as session:
             async with session.post(
-                url=redis.url,
-                headers={"Authorization": f"Bearer {redis.token}"},
+                url=redis._url,
+                headers={"Authorization": f"Bearer {redis._token}"},
                 json=["GET", "bitop_destination_4"],
             ) as response:
                 # Prevent Python from interpreting escape characters.

--- a/tests/commands/asyncio/generic/test_copy.py
+++ b/tests/commands/asyncio/generic/test_copy.py
@@ -27,17 +27,17 @@ async def test_with_replace() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.copy(source="string", destination="copy_destination_2") == 1
 
-    redis.format_return = True
+    redis._format_return = True
 
 
 @mark.asyncio
 async def test_with_formatting() -> None:
-    redis.format_return = True
+    redis._format_return = True
 
     async with redis:
         await redis.copy(source="string", destination="copy_destination_2")

--- a/tests/commands/asyncio/generic/test_expire.py
+++ b/tests/commands/asyncio/generic/test_expire.py
@@ -18,9 +18,9 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.expire("non_existing_key", seconds=1) == 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_expireat.py
+++ b/tests/commands/asyncio/generic/test_expireat.py
@@ -23,11 +23,11 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert (
             await redis.expireat("non_existing_key", unix_time_seconds=1704067200) == 0
         )
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_persist.py
+++ b/tests/commands/asyncio/generic/test_persist.py
@@ -17,10 +17,10 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         # "string" doesn't have an expiry time set.
         assert await redis.persist("string") == 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_pexpire.py
+++ b/tests/commands/asyncio/generic/test_pexpire.py
@@ -18,9 +18,9 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.pexpire("non_existing_key", milliseconds=1000) == 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_pexpireat.py
+++ b/tests/commands/asyncio/generic/test_pexpireat.py
@@ -23,7 +23,7 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert (
@@ -31,4 +31,4 @@ async def test_without_formatting() -> None:
             == 0
         )
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_renamenx.py
+++ b/tests/commands/asyncio/generic/test_renamenx.py
@@ -11,9 +11,9 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.renamenx("string", newkey="string") == 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/generic/test_scan.py
+++ b/tests/commands/asyncio/generic/test_scan.py
@@ -32,10 +32,10 @@ async def test_with_scan_type() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         result = await redis.scan(cursor=0)
         assert isinstance(result[0], str) and isinstance(result[1], List)
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/geo/test_geodist.py
+++ b/tests/commands/asyncio/geo/test_geodist.py
@@ -22,11 +22,11 @@ async def test_with_unit() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert (
             await redis.geodist("test_geo_index", "Palermo", "Catania") == "166274.1516"
         )
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/geo/test_geopos.py
+++ b/tests/commands/asyncio/geo/test_geopos.py
@@ -13,11 +13,11 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.geopos("test_geo_index", "Palermo") == [
             ["13.361389338970184", "38.115556395496299"]
         ]
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/asyncio/hyperloglog/test_pfadd.py
+++ b/tests/commands/asyncio/hyperloglog/test_pfadd.py
@@ -14,9 +14,9 @@ async def test() -> None:
 
 @mark.asyncio
 async def test_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
 
     async with redis:
         assert await redis.pfadd("hyperloglog", "element_1") == 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/hash/test_hexists.py
+++ b/tests/commands/hash/test_hexists.py
@@ -24,7 +24,7 @@ def test_hexists():
 
 
 def test_hexists_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     hash_name = "myhash"
     field1 = "field1"
     field2 = "field2"
@@ -37,4 +37,4 @@ def test_hexists_without_formatting():
     assert exists_field1 is 1
     assert exists_field2 is 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/hash/test_hgetall.py
+++ b/tests/commands/hash/test_hgetall.py
@@ -25,7 +25,7 @@ def test_hgetall():
 
 
 def test_hgetall_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     hash_name = "myhash"
     fields_values = {"field1": "value1", "field2": "value2"}
@@ -36,4 +36,4 @@ def test_hgetall_without_formatting():
 
     assert isinstance(result, list)
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/hash/test_hincrbyfloat.py
+++ b/tests/commands/hash/test_hincrbyfloat.py
@@ -25,7 +25,7 @@ def test_hincrbyfloat():
 
 
 def test_hincrbyfloat_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     hash_name = "myhash"
     field = "float_counter"
@@ -38,4 +38,4 @@ def test_hincrbyfloat_without_formatting():
 
     assert isinstance(result, str)
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/hash/test_hmset.py
+++ b/tests/commands/hash/test_hmset.py
@@ -24,7 +24,7 @@ def test_hmset():
 
 
 def test_hmset_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     hash_name = "myhash"
 
@@ -36,4 +36,4 @@ def test_hmset_without_formatting():
 
     assert result == "OK"
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/hash/test_hrandfield.py
+++ b/tests/commands/hash/test_hrandfield.py
@@ -44,7 +44,7 @@ def test_hrandfield_multiple() -> None:
 
 
 def test_hrandfield_multiple_without_formatting() -> None:
-    redis.format_return = False
+    redis._format_return = False
     hash_name = "myhash"
 
     # Add fields to the hash
@@ -57,4 +57,4 @@ def test_hrandfield_multiple_without_formatting() -> None:
     assert redis.hget(hash_name, result[0]) == result[1]
     assert redis.hget(hash_name, result[2]) == result[3]
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/server/test_flushall.py
+++ b/tests/commands/server/test_flushall.py
@@ -22,9 +22,9 @@ def test_flushall():
 
 
 def test_flushall_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     result = redis.flushall()
     assert result is "OK"
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/server/test_flushdb.py
+++ b/tests/commands/server/test_flushdb.py
@@ -22,9 +22,9 @@ def test_flushdb():
 
 
 def test_flushdb_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     result = redis.flushdb()
     assert result is "OK"
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/server/test_time.py
+++ b/tests/commands/server/test_time.py
@@ -12,7 +12,7 @@ def test_time():
 
 
 def test_time_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     result = redis.time()
     assert isinstance(result, List)
@@ -21,4 +21,4 @@ def test_time_without_formatting():
     assert result[0].isdigit()
     assert result[1].isdigit()
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/sortedSet/test_zmscore.py
+++ b/tests/commands/sortedSet/test_zmscore.py
@@ -22,7 +22,7 @@ def test_zmscore():
 
 
 def test_zmscore_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     sorted_set = "sorted_set"
 
@@ -33,4 +33,4 @@ def test_zmscore_without_formatting():
 
     assert result == ["10", "30", None]
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/sortedSet/test_zpopmax.py
+++ b/tests/commands/sortedSet/test_zpopmax.py
@@ -32,7 +32,7 @@ def test_zpopmax_with_count():
 
 
 def test_zpopmax_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     sorted_set = "sorted_set"
 
     redis.zadd(sorted_set, {"member1": 10, "member2": 20, "member3": 30})
@@ -42,4 +42,4 @@ def test_zpopmax_without_formatting():
 
     assert redis.zscore(sorted_set, "member3") is None
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/sortedSet/test_zscore.py
+++ b/tests/commands/sortedSet/test_zscore.py
@@ -23,7 +23,7 @@ def test_zscore():
 
 
 def test_zscore_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     sorted_set = "sorted_set"
 
     redis.zadd(sorted_set, {"member1": 10, "member2": 20, "member3": 30})
@@ -34,4 +34,4 @@ def test_zscore_without_formatting():
     non_existent_score = redis.zscore(sorted_set, "nonexistent_member")
     assert non_existent_score is None
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/string/test_incrbyfloat.py
+++ b/tests/commands/string/test_incrbyfloat.py
@@ -25,7 +25,7 @@ def test_incrbyfloat():
 
 
 def test_incrbyfloat_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     key = "mykey"
     initial_value = 3.14
@@ -36,4 +36,4 @@ def test_incrbyfloat_without_formatting():
     result = redis.incrbyfloat(key, increment)
     assert isinstance(result, str)
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/string/test_msetnx.py
+++ b/tests/commands/string/test_msetnx.py
@@ -36,11 +36,11 @@ def test_msetnx_some_keys_exist():
 
 
 def test_msetnx_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     key_value_pairs = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
     result = redis.msetnx(key_value_pairs)
 
     assert result is 1
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/string/test_psetex.py
+++ b/tests/commands/string/test_psetex.py
@@ -31,7 +31,7 @@ def test_psetex():
 
 
 def test_psetex_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     key = "mykey"
     value = "myvalue"
     expiration_ms = 1000
@@ -40,4 +40,4 @@ def test_psetex_without_formatting():
 
     assert result == "OK"
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/string/test_set.py
+++ b/tests/commands/string/test_set.py
@@ -24,7 +24,7 @@ def test_set():
 
 
 def test_set_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     key = "mykey"
     value = "myvalue"
     ex_seconds = 10
@@ -33,7 +33,7 @@ def test_set_without_formatting():
 
     assert result == "OK"
 
-    redis.format_return = True
+    redis._format_return = True
 
 
 def test_set_invalid_parameters():

--- a/tests/commands/string/test_setex.py
+++ b/tests/commands/string/test_setex.py
@@ -24,7 +24,7 @@ def test_setex():
 
 
 def test_setex_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
     key = "mykey"
     value = "myvalue"
     ex_seconds = 10
@@ -33,4 +33,4 @@ def test_setex_without_formatting():
 
     assert result == "OK"
 
-    redis.format_return = True
+    redis._format_return = True

--- a/tests/commands/string/test_setnx.py
+++ b/tests/commands/string/test_setnx.py
@@ -27,7 +27,7 @@ def test_setnx():
 
 
 def test_setnx_without_formatting():
-    redis.format_return = False
+    redis._format_return = False
 
     key = "mykey"
     value = "myvalue"
@@ -39,4 +39,4 @@ def test_setnx_without_formatting():
     result = redis.setnx(key, "newvalue")
     assert result is 0
 
-    redis.format_return = True
+    redis._format_return = True

--- a/upstash_redis/asyncio/client.py
+++ b/upstash_redis/asyncio/client.py
@@ -30,16 +30,16 @@ class Redis(AsyncCommands):
         :param allow_telemetry: whether anonymous telemetry can be collected
         """
 
-        self.url = url
-        self.token = token
+        self._url = url
+        self._token = token
 
-        self.allow_telemetry = allow_telemetry
+        self._allow_telemetry = allow_telemetry
 
-        self.format_return = format_return
+        self._format_return = format_return
 
-        self.rest_encoding = rest_encoding
-        self.rest_retries = rest_retries
-        self.rest_retry_interval = rest_retry_interval
+        self._rest_encoding = rest_encoding
+        self._rest_retries = rest_retries
+        self._rest_retry_interval = rest_retry_interval
 
         self._headers = make_headers(token, rest_encoding, allow_telemetry)
 
@@ -100,11 +100,11 @@ class Redis(AsyncCommands):
 
         res = await async_execute(
             session=self._session,
-            url=self.url,
+            url=self._url,
             headers=self._headers,
-            encoding=self.rest_encoding,
-            retries=self.rest_retries,
-            retry_interval=self.rest_retry_interval,
+            encoding=self._rest_encoding,
+            retries=self._rest_retries,
+            retry_interval=self._rest_retry_interval,
             command=command,
         )
 
@@ -113,7 +113,7 @@ class Redis(AsyncCommands):
             main_command = f"{main_command} {command[1]}"
 
         if (
-            self.format_return
+            self._format_return
             or main_command == "HSCAN"
             or main_command == "SMEMBERS"
             or main_command == "SDIFF"

--- a/upstash_redis/client.py
+++ b/upstash_redis/client.py
@@ -30,16 +30,16 @@ class Redis(Commands):
         :param allow_telemetry: whether anonymous telemetry can be collected
         """
 
-        self.url = url
-        self.token = token
+        self._url = url
+        self._token = token
 
-        self.allow_telemetry = allow_telemetry
+        self._allow_telemetry = allow_telemetry
 
-        self.format_return = format_return
+        self._format_return = format_return
 
-        self.rest_encoding = rest_encoding
-        self.rest_retries = rest_retries
-        self.rest_retry_interval = rest_retry_interval
+        self._rest_encoding = rest_encoding
+        self._rest_retries = rest_retries
+        self._rest_retry_interval = rest_retry_interval
 
         self._headers = make_headers(token, rest_encoding, allow_telemetry)
         self._session = Session()
@@ -109,11 +109,11 @@ class Redis(Commands):
 
         res = sync_execute(
             session=self._session,
-            url=self.url,
+            url=self._url,
             headers=self._headers,
-            encoding=self.rest_encoding,
-            retries=self.rest_retries,
-            retry_interval=self.rest_retry_interval,
+            encoding=self._rest_encoding,
+            retries=self._rest_retries,
+            retry_interval=self._rest_retry_interval,
             command=command,
         )
 
@@ -122,7 +122,7 @@ class Redis(Commands):
             main_command = f"{main_command} {command[1]}"
 
         if (
-            self.format_return
+            self._format_return
             or main_command == "HSCAN"
             or main_command == "SMEMBERS"
             or main_command == "SDIFF"


### PR DESCRIPTION
We should keep the public API surface as minimal as possible.
I don't see the benefit of making the configuration related
fields of the client public. Hence, I converted all of them
to protected fields.

I have also updated the README in couple of places. I have removed
the part where we mention you could have per-command-formatting
configuration: It is a pretty bad idea to allow mutable state
on the client object.