### PR TITLE
Add pre-release workflow and bump version to 1.1.0

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Poetry
+        run: curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Build and publish
+        run: |
+          poetry config pypi-token.pypi "${{secrets.PYPI_TOKEN}}"
+          poetry build
+          poetry publish --no-interaction
+
+      - name: Generate release tag
+        run: echo "RELEASE_TAG=v$(poetry version | awk '{print $2}')-prerelease" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: "Prerelease ${{ env.RELEASE_TAG }}"
+          draft: false
+          prerelease: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "upstash-redis"
-version = "1.0.0"
+version = "1.1.0"
 description = "Serverless Redis SDK from Upstash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>", "Zgîmbău Tudor <tudor.zgimbau@gmail.com>"]

--- a/upstash_redis/__init__.py
+++ b/upstash_redis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from upstash_redis.client import Redis
 


### PR DESCRIPTION
Adding a workflow to pre-release upon push to master

Bumping version to 1.1.0 while it looks like the latest version is 0.15.0. I did this because on [PyPI upstash-redis version is 1.0.0](https://pypi.org/project/upstash-redis/) and it's from [2024 December 4th](https://pypi.org/project/upstash-redis/#history). I feel like [this release action](https://github.com/upstash/redis-py/actions/runs/7085344732) went through somehow and released with [1.0.0](https://github.com/upstash/redis-py/blob/main/pyproject.toml#L3), even though on Github latest release is still [0.15.0](https://github.com/upstash/redis-py/releases).