### PR TITLE
Use a string value for the scan cursor

### DIFF
--- a/tests/commands/asyncio/generic/test_scan.py
+++ b/tests/commands/asyncio/generic/test_scan.py
@@ -24,3 +24,13 @@ async def test_with_count(async_redis: Redis) -> None:
 @mark.asyncio
 async def test_with_scan_type(async_redis: Redis) -> None:
     assert (await async_redis.scan(cursor=0, type="hash"))[1] == ["hash"]
+
+
+@mark.asyncio
+async def test_scan_multiple_times(async_redis: Redis) -> None:
+    cursor, keys = await async_redis.scan(cursor=0, count=1)
+    assert cursor != 0
+    assert len(keys) == 1
+    cursor, keys = await async_redis.scan(cursor=cursor, count=1)
+    assert cursor != 0
+    assert len(keys) == 1

--- a/upstash_redis/commands.py
+++ b/upstash_redis/commands.py
@@ -689,7 +689,7 @@ class Commands:
         See https://redis.io/commands/scan
         """
 
-        command: List = ["SCAN", cursor]
+        command: List = ["SCAN", str(cursor)]
 
         if match is not None:
             command.extend(["MATCH", match])
@@ -1496,7 +1496,7 @@ class Commands:
         See https://redis.io/commands/hscan
         """
 
-        command: List = ["HSCAN", key, cursor]
+        command: List = ["HSCAN", key, str(cursor)]
 
         if match is not None:
             command.extend(["MATCH", match])
@@ -2571,7 +2571,7 @@ class Commands:
         See https://redis.io/commands/sscan
         """
 
-        command: List = ["SSCAN", key, cursor]
+        command: List = ["SSCAN", key, str(cursor)]
 
         if match is not None:
             command.extend(["MATCH", match])
@@ -3477,7 +3477,7 @@ class Commands:
         See https://redis.io/commands/zscan
         """
 
-        command: List = ["ZSCAN", key, cursor]
+        command: List = ["ZSCAN", key, str(cursor)]
 
         if match is not None:
             command.extend(["MATCH", match])


### PR DESCRIPTION
Since it can be quite big, sending it as a number can cause it to be larger than the max safe integer value in JSON, and result in unpredictable iteration.

Instead, it is now converted to string.

We don't have to do it for other scan commands, their cursor values are small, but I have done it anyways to be on the safe side.