### PR TITLE
disable telemetry by default

### DIFF
--- a/upstash_redis/asyncio/client.py
+++ b/upstash_redis/asyncio/client.py
@@ -35,7 +35,7 @@ class Redis(AsyncCommands):
         rest_encoding: Optional[Literal["base64"]] = "base64",
         rest_retries: int = 1,
         rest_retry_interval: float = 3,  # Seconds.
-        allow_telemetry: bool = True,
+        allow_telemetry: bool = False,
         read_your_writes: bool = True,
     ):
         """

--- a/upstash_redis/client.py
+++ b/upstash_redis/client.py
@@ -37,7 +37,7 @@ class Redis(Commands):
         rest_encoding: Optional[Literal["base64"]] = "base64",
         rest_retries: int = 1,
         rest_retry_interval: float = 3,  # Seconds.
-        allow_telemetry: bool = True,
+        allow_telemetry: bool = False,
         read_your_writes: bool = True,
     ):
         """


### PR DESCRIPTION
While investigating an issue I reported in #63 , I noticed that Upstash Redis includes telemetry. However, I couldn’t find any mention of this in the [documentation](https://upstash.com/docs/redis/overall/getstarted).

I believe this should be documented to maintain transparency with users and help them understand what data is being collected and how to enable/disable it.