### PR TITLE
DX-2960: send Upstash-Telemetry-Retry header with the attempt number

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ We collect the following:
 - SDK version
 - Platform (Vercel, AWS)
 - Python Runtime version
+- Retry attempt number of each request (to measure retry rates)
 
 You can opt out by passing `allow_telemetry=False` when initializing the Redis client:
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ We collect the following:
 - SDK version
 - Platform (Vercel, AWS)
 - Python Runtime version
-- Retry attempt number of each request (to measure retry rates)
+- Retry count of retried requests (to measure retry rates)
 
 You can opt out by passing `allow_telemetry=False` when initializing the Redis client:
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -276,7 +276,7 @@ def test_sync_execute_sends_retry_telemetry_header() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
 
 
 def test_sync_execute_without_telemetry_does_not_send_retry_header() -> None:
@@ -309,7 +309,7 @@ async def test_async_execute_sends_retry_telemetry_header() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
 
 
 @mark.asyncio

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,6 @@
 from os import environ
 from platform import python_version
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from unittest.mock import patch
 
 import pytest
@@ -242,3 +242,88 @@ def test_make_headers_on_aws() -> None:
             "Upstash-Telemetry-Runtime": f"python@v{python_version()}",
             "Upstash-Telemetry-Platform": "aws",
         }
+
+
+class _FakeResponse:
+    headers: Dict[str, str] = {}
+
+    def json(self) -> Dict[str, Any]:
+        return {"result": "OK"}
+
+
+def _failing_post(failures: int, seen: List[Dict[str, str]]):
+    """Return a fake `post` that fails `failures` times and records the headers of every call."""
+
+    def post(url: str, headers: Dict[str, str], json: Any) -> _FakeResponse:
+        seen.append(dict(headers))
+        if len(seen) <= failures:
+            raise ConnectionError("simulated network error")
+        return _FakeResponse()
+
+    return post
+
+
+def test_sync_execute_sends_retry_telemetry_header() -> None:
+    seen: List[Dict[str, str]] = []
+    with SyncHttpClient(encoding=None, retries=3, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(2, seen)):
+            assert (
+                client.execute(
+                    url="http://localhost",
+                    headers=make_headers("token", None, True),
+                    command=["GET", "a"],
+                )
+                == "OK"
+            )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
+
+
+def test_sync_execute_without_telemetry_does_not_send_retry_header() -> None:
+    seen: List[Dict[str, str]] = []
+    with SyncHttpClient(encoding=None, retries=2, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(1, seen)):
+            assert (
+                client.execute(
+                    url="http://localhost",
+                    headers=make_headers("token", None, False),
+                    command=["GET", "a"],
+                )
+                == "OK"
+            )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, None]
+
+
+@mark.asyncio
+async def test_async_execute_sends_retry_telemetry_header() -> None:
+    seen: List[Dict[str, str]] = []
+    async with AsyncHttpClient(encoding=None, retries=3, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(2, seen)):
+            assert (
+                await client.execute(
+                    url="http://localhost",
+                    headers=make_headers("token", None, True),
+                    command=["GET", "a"],
+                )
+                == "OK"
+            )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
+
+
+@mark.asyncio
+async def test_async_execute_without_telemetry_does_not_send_retry_header() -> None:
+    seen: List[Dict[str, str]] = []
+    async with AsyncHttpClient(encoding=None, retries=2, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(1, seen)):
+            assert (
+                await client.execute(
+                    url="http://localhost",
+                    headers=make_headers("token", None, False),
+                    command=["GET", "a"],
+                )
+                == "OK"
+            )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, None]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -245,7 +245,8 @@ def test_make_headers_on_aws() -> None:
 
 
 class _FakeResponse:
-    headers: Dict[str, str] = {}
+    def __init__(self) -> None:
+        self.headers: Dict[str, str] = {}
 
     def json(self) -> Dict[str, Any]:
         return {"result": "OK"}
@@ -265,8 +266,25 @@ def _failing_post(failures: int, seen: List[Dict[str, str]]):
 
 def test_sync_execute_sends_retry_telemetry_header() -> None:
     seen: List[Dict[str, str]] = []
+    headers = make_headers("token", None, True)
     with SyncHttpClient(encoding=None, retries=3, retry_interval=0) as client:
         with patch.object(client._client, "post", side_effect=_failing_post(2, seen)):
+            assert (
+                client.execute(
+                    url="http://localhost", headers=headers, command=["GET", "a"]
+                )
+                == "OK"
+            )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
+    # the shared client headers must not be mutated between attempts / requests
+    assert "Upstash-Telemetry-Retry" not in headers
+
+
+def test_sync_execute_sends_retry_telemetry_header_with_zero_retries() -> None:
+    seen: List[Dict[str, str]] = []
+    with SyncHttpClient(encoding=None, retries=0, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(0, seen)):
             assert (
                 client.execute(
                     url="http://localhost",
@@ -276,7 +294,21 @@ def test_sync_execute_sends_retry_telemetry_header() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0"]
+
+
+def test_sync_execute_sends_retry_telemetry_header_until_exhausted() -> None:
+    seen: List[Dict[str, str]] = []
+    with SyncHttpClient(encoding=None, retries=3, retry_interval=0) as client:
+        with patch.object(client._client, "post", side_effect=_failing_post(4, seen)):
+            with raises(ConnectionError):
+                client.execute(
+                    url="http://localhost",
+                    headers=make_headers("token", None, True),
+                    command=["GET", "a"],
+                )
+
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2", "3"]
 
 
 def test_sync_execute_without_telemetry_does_not_send_retry_header() -> None:
@@ -298,18 +330,19 @@ def test_sync_execute_without_telemetry_does_not_send_retry_header() -> None:
 @mark.asyncio
 async def test_async_execute_sends_retry_telemetry_header() -> None:
     seen: List[Dict[str, str]] = []
+    headers = make_headers("token", None, True)
     async with AsyncHttpClient(encoding=None, retries=3, retry_interval=0) as client:
         with patch.object(client._client, "post", side_effect=_failing_post(2, seen)):
             assert (
                 await client.execute(
-                    url="http://localhost",
-                    headers=make_headers("token", None, True),
-                    command=["GET", "a"],
+                    url="http://localhost", headers=headers, command=["GET", "a"]
                 )
                 == "OK"
             )
 
     assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
+    # the shared client headers must not be mutated between attempts / requests
+    assert "Upstash-Telemetry-Retry" not in headers
 
 
 @mark.asyncio

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -276,12 +276,12 @@ def test_sync_execute_sends_retry_telemetry_header() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
     # the shared client headers must not be mutated between attempts / requests
     assert "Upstash-Telemetry-Retry" not in headers
 
 
-def test_sync_execute_sends_retry_telemetry_header_with_zero_retries() -> None:
+def test_sync_execute_does_not_send_retry_telemetry_header_with_zero_retries() -> None:
     seen: List[Dict[str, str]] = []
     with SyncHttpClient(encoding=None, retries=0, retry_interval=0) as client:
         with patch.object(client._client, "post", side_effect=_failing_post(0, seen)):
@@ -294,7 +294,7 @@ def test_sync_execute_sends_retry_telemetry_header_with_zero_retries() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None]
 
 
 def test_sync_execute_sends_retry_telemetry_header_until_exhausted() -> None:
@@ -308,7 +308,7 @@ def test_sync_execute_sends_retry_telemetry_header_until_exhausted() -> None:
                     command=["GET", "a"],
                 )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2", "3"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2", "3"]
 
 
 def test_sync_execute_without_telemetry_does_not_send_retry_header() -> None:
@@ -340,7 +340,7 @@ async def test_async_execute_sends_retry_telemetry_header() -> None:
                 == "OK"
             )
 
-    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == ["0", "1", "2"]
+    assert [h.get("Upstash-Telemetry-Retry") for h in seen] == [None, "1", "2"]
     # the shared client headers must not be mutated between attempts / requests
     assert "Upstash-Telemetry-Retry" not in headers
 

--- a/upstash_redis/http.py
+++ b/upstash_redis/http.py
@@ -41,11 +41,11 @@ def make_headers(
 
 def _headers_for_attempt(headers: Dict[str, str], attempt: int) -> Dict[str, str]:
     """
-    Add the attempt number (0 for the first try) as a telemetry header so that
-    the server can track how often clients retry. Only added when telemetry
-    headers are present (i.e. telemetry is allowed).
+    Add the retry count as a telemetry header on retried attempts so that the
+    server can track how often clients retry. Only added when telemetry headers
+    are present (i.e. telemetry is allowed) and this is not the first attempt.
     """
-    if "Upstash-Telemetry-Sdk" not in headers:
+    if attempt == 0 or "Upstash-Telemetry-Sdk" not in headers:
         return headers
 
     return {**headers, "Upstash-Telemetry-Retry": str(attempt)}

--- a/upstash_redis/http.py
+++ b/upstash_redis/http.py
@@ -39,9 +39,6 @@ def make_headers(
     return headers
 
 
-RETRY_TELEMETRY_HEADER = "Upstash-Telemetry-Retry"
-
-
 def _headers_for_attempt(headers: Dict[str, str], attempt: int) -> Dict[str, str]:
     """
     Add the attempt number (0 for the first try) as a telemetry header so that
@@ -51,7 +48,7 @@ def _headers_for_attempt(headers: Dict[str, str], attempt: int) -> Dict[str, str
     if "Upstash-Telemetry-Sdk" not in headers:
         return headers
 
-    return {**headers, RETRY_TELEMETRY_HEADER: str(attempt)}
+    return {**headers, "Upstash-Telemetry-Retry": str(attempt)}
 
 
 class SyncHttpClient:

--- a/upstash_redis/http.py
+++ b/upstash_redis/http.py
@@ -39,6 +39,21 @@ def make_headers(
     return headers
 
 
+RETRY_TELEMETRY_HEADER = "Upstash-Telemetry-Retry"
+
+
+def _headers_for_attempt(headers: Dict[str, str], attempt: int) -> Dict[str, str]:
+    """
+    Add the retry telemetry header on retried attempts so that the server
+    can track how often clients retry. Only added when telemetry headers
+    are present (i.e. telemetry is allowed) and this is not the first attempt.
+    """
+    if attempt == 0 or "Upstash-Telemetry-Sdk" not in headers:
+        return headers
+
+    return {**headers, RETRY_TELEMETRY_HEADER: str(attempt)}
+
+
 class SyncHttpClient:
     def __init__(
         self,
@@ -65,9 +80,12 @@ class SyncHttpClient:
         response: Optional[Dict[str, Any]] = None
         last_error: Optional[Exception] = None
 
-        for attempts_left in range(max(0, self._retries), -1, -1):
+        retries = max(0, self._retries)
+        for attempt in range(retries + 1):
             try:
-                r = self._client.post(url, headers=headers, json=command)
+                r = self._client.post(
+                    url, headers=_headers_for_attempt(headers, attempt), json=command
+                )
                 sync_token = r.headers.get("Upstash-Sync-Token")
                 if self._sync_token_cb and sync_token:
                     self._sync_token_cb(sync_token)
@@ -78,7 +96,7 @@ class SyncHttpClient:
             except Exception as e:
                 last_error = e
 
-                if attempts_left > 0:
+                if attempt < retries:
                     time.sleep(self._retry_interval)
 
         if response is None:
@@ -135,9 +153,12 @@ class AsyncHttpClient:
         response: Optional[Union[Dict, List[Dict]]] = None
         last_error: Optional[Exception] = None
 
-        for attempts_left in range(max(0, self._retries), -1, -1):
+        retries = max(0, self._retries)
+        for attempt in range(retries + 1):
             try:
-                r = await self._client.post(url, headers=headers, json=command)
+                r = await self._client.post(
+                    url, headers=_headers_for_attempt(headers, attempt), json=command
+                )
                 sync_token = r.headers.get("Upstash-Sync-Token")
 
                 if self._sync_token_cb and sync_token:
@@ -148,7 +169,7 @@ class AsyncHttpClient:
             except Exception as e:
                 last_error = e
 
-                if attempts_left > 0:
+                if attempt < retries:
                     await asyncio.sleep(self._retry_interval)
 
         if response is None:

--- a/upstash_redis/http.py
+++ b/upstash_redis/http.py
@@ -44,11 +44,11 @@ RETRY_TELEMETRY_HEADER = "Upstash-Telemetry-Retry"
 
 def _headers_for_attempt(headers: Dict[str, str], attempt: int) -> Dict[str, str]:
     """
-    Add the retry telemetry header on retried attempts so that the server
-    can track how often clients retry. Only added when telemetry headers
-    are present (i.e. telemetry is allowed) and this is not the first attempt.
+    Add the attempt number (0 for the first try) as a telemetry header so that
+    the server can track how often clients retry. Only added when telemetry
+    headers are present (i.e. telemetry is allowed).
     """
-    if attempt == 0 or "Upstash-Telemetry-Sdk" not in headers:
+    if "Upstash-Telemetry-Sdk" not in headers:
         return headers
 
     return {**headers, RETRY_TELEMETRY_HEADER: str(attempt)}


### PR DESCRIPTION
## Summary

Sends an `Upstash-Telemetry-Retry: <n>` header on retried attempts when `allow_telemetry` is on — `1`, `2`, … — so the server can see how often clients retry requests. Mirrors the redis-js change.

The initial attempt does not include this header. Existing SDK telemetry remains present on every attempt and can be used as the overall request-attempt count.

## Why

The SDK retries silently on network errors (no response received). Today there is no way to tell from server-side metrics whether a database is seeing a wave of client retries. redis-server already tracks every `Upstash-Telemetry-*` header generically in the per-database `Clients.RestTelemetry` counters, so this header lands there with no server change; the exporter side is added in the corresponding upstash-cloud PR.

## Changes

- `http.py`: `_headers_for_attempt(headers, attempt)` leaves headers unchanged on the initial attempt or when telemetry is disabled, and returns a copy containing `Upstash-Telemetry-Retry` on retried attempts. Both sync and async retry loops use a forward-counting attempt index.
- `tests/test_http.py`: sync and async tests assert the header is absent on the initial attempt, is `"1"`, `"2"`, … on retries, does not mutate shared headers, and is never sent when telemetry is disabled.
- README telemetry disclosure.

## Design notes

- Sent only on retried attempts when telemetry is on; nothing is sent on the initial attempt or when telemetry is disabled.
- The value is the raw attempt number. redis-server caps distinct values per telemetry key at 50.
- Resulting Prometheus series: `upstash_user_telemetry{type="retry_1"}`, `retry_2`, … .
